### PR TITLE
Update errorformat

### DIFF
--- a/after/ftplugin/sh.vim
+++ b/after/ftplugin/sh.vim
@@ -8,9 +8,10 @@ let b:undo_ftplugin = get(b:, "undo_ftplugin", "exe") .
   \ "|unlet b:did_ftplugin_shellcheck"
 
 let s:shellcheck_efm =
-  \ '%f:%l:%c: %trror: %m,' .
-  \ '%f:%l:%c: %tarning: %m,' .
-  \ '%I%f:%l:%c: note: %m'
+  \ '%f:%l:%c: %trror: %m [SC%n],' .
+  \ '%f:%l:%c: %tarning: %m [SC%n],' .
+  \ '%I%f:%l:%c: %tote: %m [SC%n],' .
+  \ '%-G%.%#'
 
 function! s:warn(message) abort
   echohl WarningMsg


### PR DESCRIPTION
A shellcheck compiler is provided by Vim 8.2.1769. That one uses a different error format. Updating the one used by `:ShellCheck` to ue the same format.

See: https://github.com/vim/vim/blob/60c8743ab6c90e402e6ed49d27455ef7e5698abe/runtime/compiler/shellcheck.vim 