### PR TITLE
Fix gb map

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -12,7 +12,7 @@ function! s:gb() abort
     return
   end
 
-  let id = matchstr(getline('.'), ' \(error\|warning\|note\) \zs\d\+\ze')
+  let id = matchstr(getline("."), ' \(error\|warning\|note\) \zs\d\+\ze')
 
   if id =~# '^\d\+$'
     let url = "https://github.com/koalaman/shellcheck/wiki/SC" . id

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -12,7 +12,7 @@ function! s:gb() abort
     return
   end
 
-  let id = matchstr(getline(line('.')), ' \(error\|warning\|note\) \zs\d\+\ze')
+  let id = matchstr(getline('.'), ' \(error\|warning\|note\) \zs\d\+\ze')
 
   if id =~# '^\d\+$'
     let url = "https://github.com/koalaman/shellcheck/wiki/SC" . id

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -12,10 +12,10 @@ function! s:gb() abort
     return
   end
 
-  let id = matchstr(getline("."), ' \[\zsSC\d\+\ze\]$')
+  let id = matchstr(getline(line('.')), ' \(error\|warning\|note\) \zs\d\+\ze')
 
-  if id =~# '^SC\d\+$'
-    let url = "https://github.com/koalaman/shellcheck/wiki/" . id
+  if id =~# '^\d\+$'
+    let url = "https://github.com/koalaman/shellcheck/wiki/SC" . id
 
     if !exists('g:loaded_netrw')
       runtime! autoload/netrw.vim


### PR DESCRIPTION
In d2489f22 the error format this plugin was changed. The result of that is that errors went from
    
```
foo.sh|1 col 1 warning| Some ShellCheck Error. [SC####]
```
    
To:
    
```
foo.sh|1 col 1 warning ####| Some ShellCheck Error.
```
    
That means this plugins detection of SC error codes was broken. It is now fixed.
