### PR TITLE
Fix opening shellcheck wiki on vim 9.1.1485+

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -19,9 +19,12 @@ function! s:gb() abort
 
     if !exists('g:loaded_netrw')
       runtime! autoload/netrw.vim
+      runtime! autoload/netrw/os.vim
     endif
 
-    if exists('*netrw#BrowseX') && exists('*netrw#CheckIfRemote')
+    if has('patch-9.1.1485') && exists('*netrw#os#Open')
+      call netrw#os#Open(url)
+    elseif exists('*netrw#BrowseX') && exists('*netrw#CheckIfRemote')
       call netrw#BrowseX(url, netrw#CheckIfRemote())
     endif
 


### PR DESCRIPTION

In https://github.com/vim/vim/commit/ef925556cbea4d54e73388da3b3e6c06a1bbcc02 the arity of `netrw#BrowseX` changed from 2 to 1. There is now a `netrw#os#Open()` function that can be used to open URLs instead.
